### PR TITLE
Add In Development stage workflow

### DIFF
--- a/resources/git_workflow.md
+++ b/resources/git_workflow.md
@@ -46,8 +46,8 @@ All story cards are prioritized based on importance vs effort to accomplish it.
 
 ### In Development
 
-When the card is in this stage and due extern facts can't be moved to Ready For Review stage, add `blocked` label
-to the card, and leave it in this stage
+When the User Story is in this stage and due some reason it can't be moved to Ready For Review stage, add `blocked` label
+to the card leaving it in this stage. Also, comment on the User Story card explaining why it got blocked,
 
 #### Ready for Review
 

--- a/resources/git_workflow.md
+++ b/resources/git_workflow.md
@@ -44,6 +44,11 @@ You can upload files to use as example, add labels and select the project for it
 
 All story cards are prioritized based on importance vs effort to accomplish it.
 
+### In Development
+
+When the card is in this stage and due extern facts can't be moved to Ready For Review stage, add `blocked` label
+to the card, and leave it in this stage
+
 #### Ready for Review
 
 When moving cards to this stage, you should have a working solution and an open Pull


### PR DESCRIPTION
As discussed in Slack, add the `In Development` stage workflow when the US can't be completed and moved to `Read for Review`, due to extern facts.