### PR TITLE
Add our coding styleguide section to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ The entire team should contribute with this repo, giving suggestions and making 
 
 First-timer? We recommend start reading `General/Editor` and then `Process Workflow` :)
 
+## Our Coding Styleguide
+
+We don't have a specific coding styleguide. Otherwise, we use our coding styleguide from linters, that they configurations/specifications files can be found at our [linters](https://github.com/sourcelevel/linters) repository.
+
+
 ## Our Guidelines
 
 *   [General/Editor](https://github.com/sourcelevel/guidelines/blob/master/resources/general.md)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ First-timer? We recommend start reading `General/Editor` and then `Process Workf
 
 We don't have a specific coding styleguide. Otherwise, we use our coding styleguide from linters, that they configurations/specifications files can be found at our [linters](https://github.com/sourcelevel/linters) repository.
 
-
 ## Our Guidelines
 
 *   [General/Editor](https://github.com/sourcelevel/guidelines/blob/master/resources/general.md)

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ First-timer? We recommend start reading `General/Editor` and then `Process Workf
 
 ## Our Coding Styleguide
 
-We don't have a specific coding styleguide. Otherwise, we use our coding styleguide from linters, that they configurations/specifications files can be found at our [linters](https://github.com/sourcelevel/linters) repository.
+Instead of creating a specific coding styleguide for each programming language/tool that we use, we've have decided to just use linters configuration files to indicate which patterns we follow. All linters configuration files can be found in a single repository at [sourcelevel/linters](https://github.com/sourcelevel/linters).
 
 ## Our Guidelines
 


### PR DESCRIPTION
## Motivation
We need to specify our coding styleguide in our guideline, but we don't use a specific. We use it directly from linters, that they configuration files can be found at our linters repository.

### Why this is a good pratice?
 - [Why you should adopt a community-maintained javascript style guide](https://sourcelevel.io/blog/why-you-should-adopt-a-community-maintained-javascript-style-guide)

## Proposed Solution
- [x] Add `Our Coding Styleguide` section
