### PR TITLE
Rename `ClubHouse` to `Shortcut`

### DIFF
--- a/resources/git_workflow.md
+++ b/resources/git_workflow.md
@@ -1,7 +1,7 @@
 Git Workflow
 ============
 
-We follow some patterns on creating branches and this is related to our workflow in `ClubHouse`.
+We follow some patterns on creating branches and this is related to our workflow in `Shortcut`.
 
 If you didn't read [Pull Requests](https://github.com/sourcelevel/guidelines/blob/main/resources/pull_requests.md), we recommend to read it before this guide.
 
@@ -19,7 +19,7 @@ First, we create a branch using `main` as the base with the following pattern:
 
 * `chddd/user-story-card-title`
 
-Where `ddd` stands for Story Card number in ClubHouse, check some examples of naming User Story branches:
+Where `ddd` stands for Story Card number in Shortcut, check some examples of naming User Story branches:
 
 * `ch897/collect-issues-line-numbers`
 * `ch569/edit-reviewer-author`
@@ -30,7 +30,7 @@ Where `ddd` stands for Story Card number in ClubHouse, check some examples of na
 If you realize that a single branch won't be enough, you can create more branches to detail
 your work of this User Story card. For example, let us imagine the following scenario:
 
-We have a User Story `Collect issues line numbers` which its number in ClubHouse is `123`.
+We have a User Story `Collect issues line numbers` which its number in Shortcut is `123`.
 
 ![https://github.com/sourcelevel/guidelines/blob/main/images/user_story_flow.png](https://github.com/sourcelevel/guidelines/blob/main/images/user_story_flow.png)
 

--- a/resources/git_workflow.md
+++ b/resources/git_workflow.md
@@ -17,13 +17,13 @@ Now that you're familiar with `User Story`, let's understand how it reflects our
 
 First, we create a branch using `main` as the base with the following pattern:
 
-* `chddd/user-story-card-title`
+* `sc-ddd/user-story-card-title`
 
 Where `ddd` stands for Story Card number in Shortcut, check some examples of naming User Story branches:
 
-* `ch897/collect-issues-line-numbers`
-* `ch569/edit-reviewer-author`
-* `ch642/clustering-contribution-data`
+* `sc-897/collect-issues-line-numbers`
+* `sc-569/edit-reviewer-author`
+* `sc-642/clustering-contribution-data`
 
 #### More than a single branch
 
@@ -37,26 +37,26 @@ We have a User Story `Collect issues line numbers` which its number in Shortcut 
 In this case, we can start creating the branch for it using `main` as the base:
 
 ```
-git checkout -b ch123/collect-issues-line-numbers
+git checkout -b sc-123/collect-issues-line-numbers
 ```
 
 After analyzing the requirements we noticed that a single Pull Request would carry too many
 changes. So we've decided to break down our changes in n pull requests, to do so we start
-creating a new branch using `ch123/collect-issues-line-numbers` as the base, then create the
+creating a new branch using `sc-123/collect-issues-line-numbers` as the base, then create the
 new one:
 
 ```
-git checkout -b ch123/xz-add-database-migrations
+git checkout -b sc-123/xz-add-database-migrations
 ```
 
 Where `xz` stands for initials of developer, check some examples of naming sub User Story branches:
 
-* `ch321/wt-fix-reviews-count-in-repository-page`
-* `ch781/gg-remove-sales-machine-from-subscriptions`
+* `sc-321/wt-fix-reviews-count-in-repository-page`
+* `sc-781/gg-remove-sales-machine-from-subscriptions`
 
 If you developed that change in pair programming, you can use both initials ordered alphabetically:
 
-* `ch821/gg-wt-add-call-to-action-to-landing-page`
+* `sc-821/gg-wt-add-call-to-action-to-landing-page`
 
 Note that you're able to open new branches and Pull Requests as you consider necessary on working in a User Story card.
 To decide that, always keep in mind: how easy would be to review your code, so Pull Request size will be your guide.

--- a/resources/process_workflow.md
+++ b/resources/process_workflow.md
@@ -3,11 +3,11 @@ Process Workflow
 
 ## Introduction
 
-In this section we want to describe our process to create the User Stories and tasks in the ClubHouse board.
+In this section we want to describe our process to create the User Stories and tasks in the Shortcut board.
 
 ### User Story cards
 
-Each card in ClubHouse is called User Story (Story), it can be:
+Each card in Shortcut is called User Story (Story), it can be:
 
 *   Feature
 *   Chore
@@ -19,7 +19,7 @@ Examples include paying down technical debt, improving test coverage,
 upgrading library dependencies, research, devops tasks like spinning up new servers,
 database maintenance, operational tasks, writing scripts to automate those tasks, etc.
 
-We like to create the `Feature type` as SMART tasks instead of INVEST stories, so we can move short but meaningful tasks through the Clubhouse board.
+We like to create the `Feature type` as SMART tasks instead of INVEST stories, so we can move short but meaningful tasks through the Shortcut board.
 
 Each Feature task is linked to an Epic card, but we create this Epic card as an INVEST Story.
 


### PR DESCRIPTION
## Motivation

As `Clubhouse` is now `Shortcut` we also need to change the terminology in our guidelines.

## Proposed Solution

- [x] Rename  `ClubHouse` to `Shortcut`
- [x] Change the `branch` pattern from `ch123/user-story-card-title` to `sc-123/user-story-card-title`. As `Shortcut` changed it.
